### PR TITLE
removing strict dep

### DIFF
--- a/vend.gemspec
+++ b/vend.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "webmock"
 
-  s.add_dependency 'oauth2', '~> 1.0.0'
+  s.add_dependency 'oauth2'
 end


### PR DESCRIPTION
Hi,

This strict dependency broke the bundle install because of old versions we couldn't update. Maybe other people will find this useful as we did.
